### PR TITLE
feat: 구독취소 기능 추가

### DIFF
--- a/src/main/java/com/haruhan/common/error/StatusCode.java
+++ b/src/main/java/com/haruhan/common/error/StatusCode.java
@@ -6,9 +6,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum StatusCode {
     OK(200, "요청이 성공적으로 처리되었습니다.", HttpStatus.OK),
-    ALREADY_EXIST(400, "이미 존재하는 이메일입니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_EXIST(409, "이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
     NOT_EXIST(400, "데이터가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     NOT_FOUND(404, "존재하지 않는 데이터입니다.", HttpStatus.NOT_FOUND),
+    INVALID_INPUT(400, "잘못된 입력 값입니다.", HttpStatus.BAD_REQUEST),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int statusCode;

--- a/src/main/java/com/haruhan/user/controller/UserController.java
+++ b/src/main/java/com/haruhan/user/controller/UserController.java
@@ -4,12 +4,10 @@ import com.haruhan.common.error.StatusCode;
 import com.haruhan.common.error.dto.Message;
 import com.haruhan.user.dto.UserRequestDto;
 import com.haruhan.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/user")
@@ -19,8 +17,14 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/subscribe")
-    public ResponseEntity<Message> subscribe(@RequestBody UserRequestDto requestDto) {
+    public ResponseEntity<Message> subscribe(@Valid @RequestBody UserRequestDto requestDto) {
         userService.subscribe(requestDto);
+        return ResponseEntity.ok(new Message(StatusCode.OK));
+    }
+
+    @DeleteMapping("/unsubscribe")
+    public ResponseEntity<Message> unsubscribe(@RequestParam String email) {
+        userService.unsubscribe(email);
         return ResponseEntity.ok(new Message(StatusCode.OK));
     }
 }

--- a/src/main/java/com/haruhan/user/dto/UserRequestDto.java
+++ b/src/main/java/com/haruhan/user/dto/UserRequestDto.java
@@ -3,16 +3,18 @@ package com.haruhan.user.dto;
 import com.haruhan.user.entity.PreferedTime;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
-public class UserRequestDto {
-    @NotBlank(message = "이메일을 입력하세요.")
-    @Email(message = "올바른 이메일 형식이어야 합니다.")
-    private String email;
+public record UserRequestDto(
+        @NotBlank(message = "이메일을 입력하세요.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        String email,
 
-    private PreferedTime preferedTime;
-    private Boolean isDaily; //true면 매일 하나씩, false면 월요일에 5개
-}
+        @NotNull
+        PreferedTime preferedTime,
+
+        @NotNull
+        Boolean isDaily
+) {}

--- a/src/main/java/com/haruhan/user/entity/PreferedTime.java
+++ b/src/main/java/com/haruhan/user/entity/PreferedTime.java
@@ -1,6 +1,8 @@
 package com.haruhan.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.haruhan.common.error.CustomException;
+import com.haruhan.common.error.StatusCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +22,9 @@ public enum PreferedTime {
         return Arrays.stream(PreferedTime.values())
                 .filter(preferedTime -> preferedTime.displayName.equals(value))
                 .findFirst()
-                .orElse(null); // 예외를 던지는 대신 null 반환
+                .orElseThrow(() -> new CustomException(StatusCode.INVALID_INPUT));
     }
 }
+//클라이언트가 세 가지 옵션 중 하나를 선택하면 해당 시간에 이메일을 받을 수 있는 기능을 구현할 구조o
+//저장된 preferedTime을 기반으로 이메일을 해당 시간에 전송하는 로직 필요
+//이메일 전송 기능이 추가된 후, 이와 연관지어 사용자가 선택한 시간에 전송하면 됨

--- a/src/main/java/com/haruhan/user/entity/User.java
+++ b/src/main/java/com/haruhan/user/entity/User.java
@@ -1,17 +1,14 @@
 package com.haruhan.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor  // JPA 기본 생성자 필수
 @AllArgsConstructor
 @Table(name = "user")
 public class User {
@@ -24,6 +21,7 @@ public class User {
     private String email;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private PreferedTime preferedTime;
 
     @Column(nullable = false, updatable = false)
@@ -31,4 +29,12 @@ public class User {
 
     @Column(nullable = false)
     private Boolean isDaily;
+
+
+    public User(String email, PreferedTime preferedTime, Boolean isDaily) {
+        this.email = email;
+        this.preferedTime = preferedTime;
+        this.isDaily = isDaily;
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/haruhan/user/service/UserService.java
+++ b/src/main/java/com/haruhan/user/service/UserService.java
@@ -5,4 +5,6 @@ import com.haruhan.user.dto.UserRequestDto;
 
 public interface UserService {
     void subscribe(UserRequestDto requestDto);
+
+    void unsubscribe(String email);
 }

--- a/src/main/java/com/haruhan/user/service/UserServiceImpl.java
+++ b/src/main/java/com/haruhan/user/service/UserServiceImpl.java
@@ -19,16 +19,21 @@ public class UserServiceImpl implements UserService {
     @Override
     public void subscribe(UserRequestDto requestDto) {
         // 이미 가입된 이메일인지 확인
-        if (userRepository.findByEmail(requestDto.getEmail()).isPresent()) {
+        if (userRepository.findByEmail(requestDto.email()).isPresent()) {
             throw new CustomException(StatusCode.ALREADY_EXIST);
         }
 
         // 새 사용자 추가
-        User user = new User();
-        user.setEmail(requestDto.getEmail());
-        user.setPreferedTime(requestDto.getPreferedTime());
-        user.setIsDaily(requestDto.getIsDaily());
+        User user = new User(requestDto.email(), requestDto.preferedTime(), requestDto.isDaily());
         userRepository.save(user);
+    }
 
+    @Transactional
+    @Override
+    public void unsubscribe(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(StatusCode.NOT_EXIST));
+
+        userRepository.delete(user);
     }
 }

--- a/src/test/java/com/haruhan/user/controller/UserControllerTest.java
+++ b/src/test/java/com/haruhan/user/controller/UserControllerTest.java
@@ -1,0 +1,68 @@
+package com.haruhan.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haruhan.common.error.CustomException;
+import com.haruhan.common.error.StatusCode;
+import com.haruhan.user.dto.UserRequestDto;
+import com.haruhan.user.entity.PreferedTime;
+import com.haruhan.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    @DisplayName("올바른 구독 요청이면 HTTP 200 응답을 받아야 한다.")
+    void 올바른_구독_요청_200확인() throws Exception {
+        // Given
+        UserRequestDto validDto = new UserRequestDto("test@example.com", PreferedTime.MORNING, true);
+        doNothing().when(userService).subscribe(any(UserRequestDto.class));
+
+        // When & Then
+        mockMvc.perform(post("/user/subscribe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validDto)))
+                .andExpect(status().isOk());
+
+        verify(userService, times(1)).subscribe(any(UserRequestDto.class));
+    }
+
+    @Test
+    @DisplayName("이미 구독된 이메일이면 409 Conflict 응답을 받아야 한다.")
+    void 이미_구독된_이메일_409_확인() throws Exception {
+        // Given
+        UserRequestDto duplicateDto = new UserRequestDto("test@example.com", PreferedTime.EVENING, false);
+        doThrow(new CustomException(StatusCode.ALREADY_EXIST))
+                .when(userService).subscribe(any(UserRequestDto.class));
+
+        // When & Then
+        mockMvc.perform(post("/user/subscribe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(duplicateDto)))
+                .andExpect(status().isConflict());
+
+        verify(userService, times(1)).subscribe(any(UserRequestDto.class));
+    }
+}

--- a/src/test/java/com/haruhan/user/service/UserServiceTest.java
+++ b/src/test/java/com/haruhan/user/service/UserServiceTest.java
@@ -1,17 +1,16 @@
 package com.haruhan.user.service;
 
+import com.haruhan.common.error.CustomException;
+import com.haruhan.common.error.StatusCode;
 import com.haruhan.user.dto.UserRequestDto;
 import com.haruhan.user.entity.PreferedTime;
 import com.haruhan.user.entity.User;
 import com.haruhan.user.repository.UserRepository;
-import com.haruhan.common.error.CustomException;
-import com.haruhan.common.error.StatusCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -19,51 +18,46 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(MockitoExtension.class)  // Mockito 확장 사용
+@ExtendWith(MockitoExtension.class) // Mockito 확장 사용
 class UserServiceTest {
 
     @Mock
-    private UserRepository userRepository;  // Mock 객체
+    private UserRepository userRepository; // Mock 객체
 
     @InjectMocks
-    private UserServiceImpl userService;  // 테스트할 서비스
+    private UserServiceImpl userService; // 테스트할 서비스
 
     private UserRequestDto requestDto;
 
     @BeforeEach
     void setUp() {
-        requestDto = new UserRequestDto();
-        requestDto.setEmail("test@example.com");
-        requestDto.setPreferedTime(PreferedTime.MORNING);
-        requestDto.setIsDaily(true);
+        requestDto = new UserRequestDto("test@example.com", PreferedTime.MORNING, true);
     }
 
     @Test
     void 구독_성공() {
         // Given: 이메일이 없는 상태(Mock 설정)
-        when(userRepository.findByEmail(requestDto.getEmail())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(requestDto.email())).thenReturn(Optional.empty());
 
-        // When: 구독 요청 (void 메서드이므로 반환값 확인 X)
+        // When & Then: 예외가 발생하지 않는지 확인 (void 메서드)
         assertDoesNotThrow(() -> userService.subscribe(requestDto));
 
-        // Then: 저장이 한 번 호출되었는지 검증
+        // User 객체가 올바르게 저장되었는지 검증
         verify(userRepository, times(1)).save(any(User.class));
     }
 
     @Test
     void 이미_구독된_이메일이면_예외발생() {
         // Given: 이미 존재하는 이메일(Mock 설정)
-        when(userRepository.findByEmail(requestDto.getEmail()))
-                .thenReturn(Optional.of(new User()));
+        when(userRepository.findByEmail(requestDto.email()))
+                .thenReturn(Optional.of(new User(requestDto.email(), requestDto.preferedTime(), requestDto.isDaily())));
 
         // When & Then: 예외 발생 확인
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            userService.subscribe(requestDto);
-        });
+        CustomException exception = assertThrows(CustomException.class, () -> userService.subscribe(requestDto));
 
         assertEquals(StatusCode.ALREADY_EXIST, exception.getStatusCode());
 
-        // save가 호출되지 않았는지 검증
+        // save()가 호출되지 않았는지 검증
         verify(userRepository, never()).save(any(User.class));
     }
 }


### PR DESCRIPTION
- 제목 : feat: 구독취소 기능 추가

## 🔘Part

- [x] BE
  <br/>

## 🔎 작업 내용

- dto 형식을 record로 수정

- 메일 전송 기능이 구현되기 전, 임시로 파라미터에 이메일을 받아 구독취소 기능 구현

- 빈도 설정도 구조 잡아놓음

  <br/>

## 🔧 앞으로의 과제

- 메일전송 완료되면 리팩토링

  <br/>
