### PR TITLE
fix(58) : 구독하기 기능 중 인증번호 이메일 발신 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // AWS SDK for SES (Simple Email Service)
+    implementation 'com.amazonaws:aws-java-sdk-ses:1.12.781'
+
+    // Redis 의존성 (Spring Boot 3.x에서는 lettuce 사용)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // JSON 처리 (AWS SDK에서 JSON 요청 시 필요)
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/haruhan/common/error/StatusCode.java
+++ b/src/main/java/com/haruhan/common/error/StatusCode.java
@@ -12,6 +12,7 @@ public enum StatusCode {
     NOT_FOUND_USER(404, "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
     INVALID_INPUT(400, "잘못된 입력 값입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_BOOKMARKED(409, "이미 찜한 컨텐츠입니다.", HttpStatus.CONFLICT),
+    INVALID_VERIFICATION_CODE(400, "인증번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int statusCode;

--- a/src/main/java/com/haruhan/common/error/config/AwsSesConfig.java
+++ b/src/main/java/com/haruhan/common/error/config/AwsSesConfig.java
@@ -1,0 +1,30 @@
+package com.haruhan.common.error.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsSesConfig {
+
+    @Value("${aws.ses.access-key}")
+    private String accessKey;
+
+    @Value("${aws.ses.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public AmazonSimpleEmailService amazonSimpleEmailService() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonSimpleEmailServiceClientBuilder.standard()
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+
+    }
+}

--- a/src/main/java/com/haruhan/common/error/config/RedisConfig.java
+++ b/src/main/java/com/haruhan/common/error/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.haruhan.common.error.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/haruhan/common/error/config/TemplateConfiguration.java
+++ b/src/main/java/com/haruhan/common/error/config/TemplateConfiguration.java
@@ -1,0 +1,18 @@
+package com.haruhan.common.error.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
+
+@Configuration
+public class TemplateConfiguration {
+    @Bean
+    public TemplateEngine htmlTemplateEngine(SpringResourceTemplateResolver springResourceTemplateResolver) {
+        TemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(springResourceTemplateResolver);
+
+        return templateEngine;
+    }
+}

--- a/src/main/java/com/haruhan/user/controller/UserController.java
+++ b/src/main/java/com/haruhan/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.haruhan.user.controller;
 
 import com.haruhan.common.error.StatusCode;
 import com.haruhan.common.error.dto.Message;
+import com.haruhan.user.dto.UserConfirmRequestDto;
 import com.haruhan.user.dto.UserRequestDto;
 import com.haruhan.user.dto.UserSettingRequestDto;
 import com.haruhan.user.service.UserService;
@@ -34,5 +35,12 @@ public class UserController {
     public ResponseEntity<Message> updateUserSettings(@Valid @RequestBody UserSettingRequestDto requestDto) {
         userService.updateUserSettings(requestDto);
         return ResponseEntity.ok(new Message(StatusCode.OK));
+    }
+
+    // 2. 인증번호 검증 및 구독 완료
+    @PostMapping("/confirm-subscribe")
+    public ResponseEntity<Message> confirmSubscribe(@RequestBody UserConfirmRequestDto userConfirmRequestDto) {
+        userService.confirmSubscription(userConfirmRequestDto);
+        return ResponseEntity.ok(new Message(StatusCode.OK, "구독이 완료되었습니다."));
     }
 }

--- a/src/main/java/com/haruhan/user/dto/UserConfirmRequestDto.java
+++ b/src/main/java/com/haruhan/user/dto/UserConfirmRequestDto.java
@@ -1,0 +1,11 @@
+package com.haruhan.user.dto;
+
+import com.haruhan.user.entity.PreferedTime;
+
+public record UserConfirmRequestDto(
+        String email,
+        PreferedTime preferedTime,
+        Boolean isDaily,
+        String verificationCode
+) {}
+

--- a/src/main/java/com/haruhan/user/service/EmailService.java
+++ b/src/main/java/com/haruhan/user/service/EmailService.java
@@ -1,0 +1,72 @@
+package com.haruhan.user.service;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.model.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+
+    private final AmazonSimpleEmailService amazonSimpleEmailService;
+    private final TemplateEngine templateEngine;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String FROM = "kdh10045098@gmail.com"; // SES에 등록된 발신자 이메일
+    private static final long EXPIRATION_TIME = 5; // 인증번호 만료 시간 (5분)
+
+    public void sendVerificationEmail(String email) {
+        String verificationCode = generateRandomCode(); // 인증번호 생성
+        saveVerificationCode(email, verificationCode); // Redis에 저장
+
+        // Thymeleaf를 이용하여 HTML 이메일 본문 생성
+        Context context = new Context();
+        context.setVariable("code", verificationCode); // 인증번호 전달
+        String htmlContent = templateEngine.process("verification-email", context); // verification-email.html 사용
+
+        // AWS SES 이메일 요청 생성
+        SendEmailRequest request = new SendEmailRequest()
+                .withDestination(new Destination().withToAddresses(email))
+                .withMessage(new Message()
+                        .withBody(new Body()
+                                .withHtml(new Content()
+                                        .withCharset("UTF-8")
+                                        .withData(htmlContent))
+                                .withText(new Content()
+                                        .withCharset("UTF-8")
+                                        .withData("Your verification code is: " + verificationCode)))
+                        .withSubject(new Content()
+                                .withCharset("UTF-8")
+                                .withData("Your Verification Code")))
+                .withSource(FROM);
+
+        // 이메일 전송
+        amazonSimpleEmailService.sendEmail(request);
+        log.info("Sent verification code to: {}", email);
+    }
+
+    private void saveVerificationCode(String email, String code) {
+        String key = "email_verification:" + email;
+        redisTemplate.opsForValue().set(key, code, EXPIRATION_TIME, TimeUnit.MINUTES);
+    }
+
+    private String generateRandomCode() {
+        Random random = new Random();
+        return String.format("%04d", random.nextInt(10000)); // 4자리 인증번호 생성
+    }
+
+    public boolean verifyCode(String email, String inputCode) {
+        String key = "email_verification:" + email;
+        String storedCode = redisTemplate.opsForValue().get(key);
+        return storedCode != null && storedCode.equals(inputCode);
+    }
+}

--- a/src/main/java/com/haruhan/user/service/EmailService.java
+++ b/src/main/java/com/haruhan/user/service/EmailService.java
@@ -21,7 +21,7 @@ public class EmailService {
     private final TemplateEngine templateEngine;
     private final RedisTemplate<String, String> redisTemplate;
 
-    private static final String FROM = "kdh10045098@gmail.com"; // SES에 등록된 발신자 이메일
+    private static final String FROM = "no-reply@haruhan.site"; // SES에 등록된 발신자 이메일
     private static final long EXPIRATION_TIME = 5; // 인증번호 만료 시간 (5분)
 
     public void sendVerificationEmail(String email) {

--- a/src/main/java/com/haruhan/user/service/UserService.java
+++ b/src/main/java/com/haruhan/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.haruhan.user.service;
 
 
+import com.haruhan.user.dto.UserConfirmRequestDto;
 import com.haruhan.user.dto.UserRequestDto;
 import com.haruhan.user.dto.UserSettingRequestDto;
 
@@ -10,4 +11,6 @@ public interface UserService {
     void unsubscribe(String email);
 
     void updateUserSettings(UserSettingRequestDto requestDto);
+
+    void confirmSubscription(UserConfirmRequestDto userConfirmRequestDto);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,9 +20,20 @@ spring:
       hibernate:
         format_sql: true
 
+  data:
+    redis:
+      host: ${redis_host}
+      port: ${redis_port}
+      password: ${redis_password}
+
 logging:
   level:
     root: info
+
+aws:
+  ses:
+    access-key: ${aws_access_key}
+    secret-key: ${aws_secret_key}
 
 profiles:
   active: dev

--- a/src/main/resources/templates/verification-email.html
+++ b/src/main/resources/templates/verification-email.html
@@ -1,13 +1,30 @@
 <!DOCTYPE html>
-<html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta charset="UTF-8">
-    <title>Email Verification</title>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HaruHan</title>
 </head>
-<body>
-<h2>Email Verification Code</h2>
-<p>Hello,</p>
-<p>Your verification code is: <strong th:text="${code}"></strong></p>
-<p>This code will expire in 5 minutes.</p>
+<body style="font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #f5f5f5;">
+<div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="background-color: #ffffff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+        <a href="#" style="text-decoration: none; color: #333;">
+            <p style="font-size: 24px; font-weight: bold; margin: 0;">HaruHan</p>
+        </a>
+        <h2 style="color: #333; margin: 20px 0;">HaruHan 구독을 환영합니다.</h2>
+        <p style="color: #666; line-height: 1.6;">
+            <br>
+            인증번호 : <strong th:text="${code}"></strong><br>
+            <br>
+            HaruHan지식 구독에 필요한 인증번호입니다.<br>
+            위 인증번호를 입력하여 이메일 주소 인증을 완료해주시기 바랍니다.<br>
+            <br>
+            HaruHan을 찾아주셔서 진심으로 감사드립니다.<br/>
+            <br/>
+            <span style="font-size: 14px; color: #888; font-style: italic;">*구독자분들의 휴식을 위해, 주말에는 메일을 보내드리지 않아요. 참고해 주세요.</span> <br>
+        </p>
+    </div>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/verification-email.html
+++ b/src/main/resources/templates/verification-email.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Email Verification</title>
+</head>
+<body>
+<h2>Email Verification Code</h2>
+<p>Hello,</p>
+<p>Your verification code is: <strong th:text="${code}"></strong></p>
+<p>This code will expire in 5 minutes.</p>
+</body>
+</html>


### PR DESCRIPTION
- 제목 : fix(58) : 구독하기 기능 중 인증번호 이메일 발신 기능 추가

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- Amazon SES와 연동하여 입력된 이메일로 무작위 인증번호를 보내는 기능 추가

- 받은 인증번호를 입력하여 일치하는지 확인하는 기능 추가

  <br/>

## 🔧 앞으로의 과제

- Amazon SES Production 모드 승인 받기

  <br/>

## ➕ 이슈 링크

- [BE #58 ](https://github.com/HaruHan-Mail/BE/issues/58)

<br/>
