### PR TITLE
fix(58) : RedisConf 파일에서 포트를 int로 명시

### DIFF
--- a/src/main/java/com/haruhan/common/error/config/RedisConfig.java
+++ b/src/main/java/com/haruhan/common/error/config/RedisConfig.java
@@ -1,15 +1,28 @@
 package com.haruhan.common.error.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableCaching
 public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisHost, redisPort);
+        return new LettuceConnectionFactory(configuration);
+    }
 
     @Bean
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {


### PR DESCRIPTION
- 제목 : fix(58) : RedisConf 파일에서 포트를 int로 명시

## 🔘Part

- [x] BE

  <br/>

## ➕ 이슈 링크

- [BE #58 ]

<br/>
