### PR TITLE
fix(87) : user token 추가 및 관련 메소드, 요청에 token이 필요하도록 수정

### DIFF
--- a/src/main/java/com/haruhan/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/haruhan/bookmark/controller/BookmarkController.java
@@ -1,5 +1,6 @@
 package com.haruhan.bookmark.controller;
 
+import com.haruhan.bookmark.dto.BookmarkGetReqDto;
 import com.haruhan.bookmark.dto.BookmarkReqDto;
 import com.haruhan.bookmark.service.BookmarkService;
 import com.haruhan.common.error.StatusCode;
@@ -29,8 +30,8 @@ public class BookmarkController {
     }
 
     @GetMapping("/{userEmail}")
-    public ResponseEntity<Message> getAllBookmarks(@PathVariable String userEmail) {
-        return ResponseEntity.ok(new Message(StatusCode.OK, bookmarkService.getBookmarkContent(userEmail)));
+    public ResponseEntity<Message> getAllBookmarks(@RequestBody BookmarkGetReqDto bookmarkGetReqDto) {
+        return ResponseEntity.ok(new Message(StatusCode.OK, bookmarkService.getBookmarkContent(bookmarkGetReqDto)));
     }
 
     @GetMapping

--- a/src/main/java/com/haruhan/bookmark/dto/BookmarkGetReqDto.java
+++ b/src/main/java/com/haruhan/bookmark/dto/BookmarkGetReqDto.java
@@ -1,0 +1,7 @@
+package com.haruhan.bookmark.dto;
+
+public record BookmarkGetReqDto(
+        String userEmail,
+        String token
+) {
+}

--- a/src/main/java/com/haruhan/bookmark/dto/BookmarkReqDto.java
+++ b/src/main/java/com/haruhan/bookmark/dto/BookmarkReqDto.java
@@ -2,5 +2,6 @@ package com.haruhan.bookmark.dto;
 
 public record BookmarkReqDto(
         String userEmail,
+        String token,
         Long contentId
 ) {}

--- a/src/main/java/com/haruhan/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/haruhan/bookmark/service/BookmarkService.java
@@ -1,5 +1,6 @@
 package com.haruhan.bookmark.service;
 
+import com.haruhan.bookmark.dto.BookmarkGetReqDto;
 import com.haruhan.bookmark.dto.BookmarkGetResDto;
 import com.haruhan.bookmark.dto.BookmarkReqDto;
 
@@ -8,6 +9,6 @@ import java.util.List;
 public interface BookmarkService {
     void addBookmark(BookmarkReqDto bookmarkReqDto);
     void deleteBookmark(BookmarkReqDto bookmarkReqDto);
-    List<BookmarkGetResDto> getBookmarkContent(String userEmail);
+    List<BookmarkGetResDto> getBookmarkContent(BookmarkGetReqDto bookmarkGetReqDto);
     boolean isBookmarked(BookmarkReqDto bookmarkReqDto);
 }

--- a/src/main/java/com/haruhan/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/haruhan/bookmark/service/BookmarkServiceImpl.java
@@ -1,5 +1,6 @@
 package com.haruhan.bookmark.service;
 
+import com.haruhan.bookmark.dto.BookmarkGetReqDto;
 import com.haruhan.bookmark.dto.BookmarkGetResDto;
 import com.haruhan.bookmark.dto.BookmarkReqDto;
 import com.haruhan.bookmark.entity.Bookmark;
@@ -30,7 +31,7 @@ public class BookmarkServiceImpl implements BookmarkService {
     // 사용 가능한 데이터인지 확인하는 메소드
     private Bookmark isUsableData(BookmarkReqDto bookmarkReqDto) {
         // 이메일로 사용자 찾기
-        User user = userRepository.findByEmail(bookmarkReqDto.userEmail())
+        User user = userRepository.findByToken(bookmarkReqDto.token())
                 .orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND_USER));
 
         // 컨텐츠 찾기
@@ -73,9 +74,9 @@ public class BookmarkServiceImpl implements BookmarkService {
     }
 
     @Override
-    public List<BookmarkGetResDto> getBookmarkContent(String userEmail) {
+    public List<BookmarkGetResDto> getBookmarkContent(BookmarkGetReqDto bookmarkGetReqDto) {
         // 이메일로 사용자 찾기
-        User user = userRepository.findByEmail(userEmail)
+        User user = userRepository.findByToken(bookmarkGetReqDto.token())
                 .orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND_USER));
 
         // 사용자의 찜한 지식 목록 가져오기

--- a/src/main/java/com/haruhan/user/controller/UserController.java
+++ b/src/main/java/com/haruhan/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.haruhan.common.error.dto.Message;
 import com.haruhan.user.dto.UserConfirmRequestDto;
 import com.haruhan.user.dto.UserRequestDto;
 import com.haruhan.user.dto.UserSettingRequestDto;
+import com.haruhan.user.dto.UserUnsubscribeRequestDto;
 import com.haruhan.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,8 @@ public class UserController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Message> unsubscribe(@RequestParam String email) {
-        userService.unsubscribe(email);
+    public ResponseEntity<Message> unsubscribe(@RequestBody UserUnsubscribeRequestDto userUnsubscribeRequestDto) {
+        userService.unsubscribe(userUnsubscribeRequestDto);
         return ResponseEntity.ok(new Message(StatusCode.OK));
     }
 

--- a/src/main/java/com/haruhan/user/dto/UserSettingRequestDto.java
+++ b/src/main/java/com/haruhan/user/dto/UserSettingRequestDto.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.NotNull;
 public record UserSettingRequestDto (
         @NotNull String email,
         @NotNull PreferedTime preferedTime,
-        @NotNull boolean isDaily
-
+        @NotNull boolean isDaily,
+        @NotNull String token
 ) {}

--- a/src/main/java/com/haruhan/user/dto/UserUnsubscribeRequestDto.java
+++ b/src/main/java/com/haruhan/user/dto/UserUnsubscribeRequestDto.java
@@ -1,0 +1,9 @@
+package com.haruhan.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserUnsubscribeRequestDto(
+        @NotNull String email,
+        @NotNull String token
+) {
+}

--- a/src/main/java/com/haruhan/user/entity/User.java
+++ b/src/main/java/com/haruhan/user/entity/User.java
@@ -2,10 +2,14 @@ package com.haruhan.user.entity;
 
 import com.haruhan.bookmark.entity.Bookmark;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -32,6 +36,9 @@ public class User {
     @Column(nullable = false)
     private Boolean isDaily;
 
+    @Column(nullable = false, unique = true)
+    private String token;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     //orphanRemoval : 연결이 끊어진(null이 된) 북마크 엔티티를 자동 삭제
     private List<Bookmark> bookmarks;
@@ -42,6 +49,7 @@ public class User {
         this.preferedTime = preferedTime;
         this.isDaily = isDaily;
         this.createdAt = LocalDateTime.now();
+        this.token = UUID.randomUUID().toString();
     }
 
     public void updateSettings(PreferedTime preferedTime, boolean isDaily) {

--- a/src/main/java/com/haruhan/user/repository/UserRepository.java
+++ b/src/main/java/com/haruhan/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByToken(String token);
 }

--- a/src/main/java/com/haruhan/user/service/UserService.java
+++ b/src/main/java/com/haruhan/user/service/UserService.java
@@ -4,11 +4,12 @@ package com.haruhan.user.service;
 import com.haruhan.user.dto.UserConfirmRequestDto;
 import com.haruhan.user.dto.UserRequestDto;
 import com.haruhan.user.dto.UserSettingRequestDto;
+import com.haruhan.user.dto.UserUnsubscribeRequestDto;
 
 public interface UserService {
     void subscribe(UserRequestDto requestDto);
 
-    void unsubscribe(String email);
+    void unsubscribe(UserUnsubscribeRequestDto userUnsubscribeRequestDto);
 
     void updateUserSettings(UserSettingRequestDto requestDto);
 

--- a/src/main/java/com/haruhan/user/service/UserServiceImpl.java
+++ b/src/main/java/com/haruhan/user/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.haruhan.common.error.StatusCode;
 import com.haruhan.user.dto.UserConfirmRequestDto;
 import com.haruhan.user.dto.UserRequestDto;
 import com.haruhan.user.dto.UserSettingRequestDto;
+import com.haruhan.user.dto.UserUnsubscribeRequestDto;
 import com.haruhan.user.entity.User;
 import com.haruhan.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -32,8 +33,8 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public void unsubscribe(String email) {
-        User user = userRepository.findByEmail(email)
+    public void unsubscribe(UserUnsubscribeRequestDto userUnsubscribeRequestDto) {
+        User user = userRepository.findByToken(userUnsubscribeRequestDto.token())
                 .orElseThrow(() -> new CustomException(StatusCode.NOT_EXIST));
 
         userRepository.delete(user);
@@ -42,7 +43,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void updateUserSettings(UserSettingRequestDto requestDto) {
-        User user = userRepository.findByEmail(requestDto.email())
+        User user = userRepository.findByToken(requestDto.token())
                 .orElseThrow(() -> new CustomException(StatusCode.NOT_EXIST));
 
         user.updateSettings(requestDto.preferedTime(), requestDto.isDaily());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 server:
   port: 8082
   address: 0.0.0.0
+  tomcat:
+    remoteip:
+      protocol-header: x-forwarded-proto
 
 spring:
   application:


### PR DESCRIPTION
- 제목 : fix(87) : user token 추가 및 관련 메소드, 요청에 token이 필요하도록 수정

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 새로운 구독 유저가 생성될때 고유한 User Token이 생성되도록 수정

- 찜하기, 수신 빈도 설정, 구독 해제 기능의 매개변수에 Token값 추가

  <br/>

## 🔧 앞으로의 과제

- 예시 템플릿 이메일 보내기 기능 추가

- Amazon SES production 모드로 변경 신청하기

  <br/>

## ➕ 이슈 링크

- [BE #87 ]

<br/>
