### PR TITLE
fix(111) : 구독 완료시 웰컴 이메일 보내주도록 수정

### DIFF
--- a/src/main/java/com/haruhan/email/service/EmailService.java
+++ b/src/main/java/com/haruhan/email/service/EmailService.java
@@ -31,7 +31,7 @@ public class EmailService {
 
     public void sendContentEmail(String email, com.haruhan.content.entity.Content content) {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND_USER));
-        Context  context = new Context();
+        Context context = new Context();
         context.setVariable("title", content.getTitle());
         context.setVariable("content_id", content.getContentId());
         context.setVariable("email", email);
@@ -52,6 +52,29 @@ public class EmailService {
 
         amazonSimpleEmailService.sendEmail(request);
         log.info("Sent question email to: {}", email);
+    }
+    public void sendWelcomeEmail(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND_USER));
+        Context context = new Context();
+        context.setVariable("email", email);
+        context.setVariable("user_id", user.getUserId());
+        context.setVariable("token", user.getToken());
+        context.setVariable("prefered_time", user.getPreferedTime());
+        String htmlContent = templateEngine.process("welcome-email", context);
+
+        SendEmailRequest request = new SendEmailRequest()
+                .withDestination(new Destination().withToAddresses(email))
+                .withMessage(new Message()
+                        .withBody(new Body()
+                                .withHtml(new Content()
+                                        .withCharset("UTF-8")
+                                        .withData(htmlContent)))
+                        .withSubject(new Content()
+                                .withCharset("UTF-8")
+                                .withData("Haruhan 지식 구독을 환영합니다!!")))
+                .withSource(FROM);
+        amazonSimpleEmailService.sendEmail(request);
+        log.info("Sent welcome email to: {}", email);
     }
 
     public void sendVerificationEmail(String email) {

--- a/src/main/java/com/haruhan/user/service/UserServiceImpl.java
+++ b/src/main/java/com/haruhan/user/service/UserServiceImpl.java
@@ -64,6 +64,7 @@ public class UserServiceImpl implements UserService {
         // 새 사용자 추가
         User user = new User(userConfirmRequestDto.email(), userConfirmRequestDto.preferedTime(), userConfirmRequestDto.isDaily());
         userRepository.save(user);
+        emailService.sendWelcomeEmail(userConfirmRequestDto.email());
     }
 
     @Override

--- a/src/main/resources/templates/welcome-email.html
+++ b/src/main/resources/templates/welcome-email.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" data-theme="light">
+<head>
+  <meta charset="UTF-8"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>haruhan - 환영합니다!</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f0f4f8;font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;color:#333;">
+<div style="max-width:600px;margin:40px auto;background-color:#ffffff;padding:20px;border-radius:12px;box-shadow:0 6px 12px rgba(0,0,0,0.08);">
+
+  <div style="text-align:center;border-bottom:2px solid #e86912;padding-bottom:15px;">
+    <img src="https://haruhan.s3.ap-northeast-2.amazonaws.com/HaruhanLogo.png" alt="haruhan 로고" style="width:140px;margin-bottom:10px;"/>
+  </div>
+
+  <div style="padding:30px;text-align:center;">
+    <h2 style="font-size:22px;margin-bottom:16px;color:#444;">🎉 환영합니다!</h2>
+    <p style="font-size:17px;line-height:1.7;margin-bottom:20px;color:#555;font-size: large;">
+      <span th:text="${email}"></span>님, <br/><b>Haruhan</b>에 오신 것을 진심으로 환영합니다!
+    </p>
+    <p style="font-size:16px;color:#777;margin-bottom:30px;">
+      당신은 <strong th:text="${user_id}"></strong>번째 사용자입니다 🎊<br/>
+      이제부터 매일 한 가지 지식을 받아보실 수 있어요!
+    </p>
+    <p style="font-size:15px;color:#888;">
+        선호 시간: <strong th:text="${prefered_time}"></strong><br/>
+      </p>
+  </div>
+
+  <div style="margin-top:30px;text-align:center;font-size:14px;color:#aaa;border-top:1px solid #eee;padding-top:20px;">
+    <a th:href="@{https://haruhan.com/setting(email=${email}, token=${token})}" style="color:#aaa;margin:0 12px;text-decoration:none;">설정</a>
+    |
+    <a th:href="@{https://haruhan.com/unsubscribe(email=${email}, token=${token})}" style="color:#aaa;margin:0 12px;text-decoration:none;">구독 해지</a>
+  </div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
- 제목 : fix(111) : 구독 완료시 웰컴 이메일 보내주도록 수정

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- welcome-email.html 템플릿 추가
- ![image](https://github.com/user-attachments/assets/0575a53a-bb79-4909-bcb4-0ef1b98aabe0)
웰컴 이메일 Context를 새로 생성해서 구독한 이메일로 보내는 기능 추가
- 웰컴 이메일엔 몇 번째로 구독한 사용자인지 함께 보내지도록 구현


  <br/>

## 🔧 앞으로의 과제

- Haruhan을 운영하며 트래픽을 관리하고 리팩토링 및 추가 기능 구현 생각하기

  <br/>

## ➕ 이슈 링크

- [BE #111]

<br/>
