### PR TITLE
fix(114) : 이메일 템플릿에 .com으로 잘못 되어있던 url 수정

### DIFF
--- a/src/main/resources/templates/welcome-email.html
+++ b/src/main/resources/templates/welcome-email.html
@@ -28,9 +28,9 @@
   </div>
 
   <div style="margin-top:30px;text-align:center;font-size:14px;color:#aaa;border-top:1px solid #eee;padding-top:20px;">
-    <a th:href="@{https://haruhan.com/setting(email=${email}, token=${token})}" style="color:#aaa;margin:0 12px;text-decoration:none;">설정</a>
+    <a th:href="@{https://haruhan.site/setting(email=${email}, token=${token})}" style="color:#aaa;margin:0 12px;text-decoration:none;">설정</a>
     |
-    <a th:href="@{https://haruhan.com/unsubscribe(email=${email}, token=${token})}" style="color:#aaa;margin:0 12px;text-decoration:none;">구독 해지</a>
+    <a th:href="@{https://haruhan.site/unsubscribe(email=${email}, token=${token})}" style="color:#aaa;margin:0 12px;text-decoration:none;">구독 해지</a>
   </div>
 
 </div>


### PR DESCRIPTION
- 제목 : fix(114) : 이메일 템플릿에 .com으로 잘못 되어있던 url 수정

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 이메일 템플릿에서 .com으로 되어있던 코드를 .site로 수정

  <br/>

## 🔧 앞으로의 과제

- 배포 및 운영
- 트래픽 관리 및 사용자 피드백 반영

  <br/>

## ➕ 이슈 링크

- [BE #114]

<br/>
