### PR TITLE
Develop -> Main

### DIFF
--- a/src/main/java/com/haruhan/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/haruhan/bookmark/repository/BookmarkRepository.java
@@ -13,5 +13,7 @@ import java.util.List;
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     boolean existsByBookmarkId(BookmarkId bookmarkId);
-    List<Bookmark> findByUser(User user);
+
+    @Query("SELECT b FROM Bookmark b JOIN FETCH b.content WHERE b.user = :user")
+    List<Bookmark> findByUserFetchContent(@Param("user") User user);
 }

--- a/src/main/java/com/haruhan/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/haruhan/bookmark/service/BookmarkServiceImpl.java
@@ -75,7 +75,6 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     @Override
     public List<BookmarkGetResDto> getBookmarkContent(String email, String token) {
-        // 토큰으로 사용자 찾기
         User user = userRepository.findByToken(token)
                 .orElseThrow(() -> new CustomException(StatusCode.NOT_FOUND_USER));
 
@@ -83,11 +82,8 @@ public class BookmarkServiceImpl implements BookmarkService {
             throw new CustomException(StatusCode.INVALID_INPUT);
         }
 
-        // 사용자의 찜한 지식 목록 가져오기
-        List<Bookmark> bookmarks = bookmarkRepository.findByUser(user);
+        List<Bookmark> bookmarks = bookmarkRepository.findByUserFetchContent(user);
 
-
-        // Bookmark를 DTO로 변환 후 반환
         return bookmarks.stream()
                 .map(bookmark -> new BookmarkGetResDto(
                         bookmark.getContent().getContentId(),
@@ -97,7 +93,8 @@ public class BookmarkServiceImpl implements BookmarkService {
                         splitByNewLine(bookmark.getContent().getImportance()),
                         splitByNewLine(bookmark.getContent().getTip()),
                         splitByNewLine(bookmark.getContent().getAdditionalResources())
-                )).collect(Collectors.toList());
+                ))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/haruhan/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/haruhan/bookmark/service/BookmarkServiceImpl.java
@@ -85,9 +85,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 
         // 사용자의 찜한 지식 목록 가져오기
         List<Bookmark> bookmarks = bookmarkRepository.findByUser(user);
-        if (bookmarks.isEmpty()) {
-            throw new CustomException(StatusCode.NOT_EXIST);
-        }
+
 
         // Bookmark를 DTO로 변환 후 반환
         return bookmarks.stream()


### PR DESCRIPTION
### - fix: 북마크 조회 시 N+1 문제 해결

## 🔘Part

- [x] BE

## 🔎 작업 내용

- 기존에는 북마크와 연결된 콘텐츠를 각각 개별 조회하면서, 북마크 수만큼 불필요한 다수의 쿼리가 발생

- bookmark와 content를 JOIN하여 한 번의 쿼리로 모든 콘텐츠 데이터를 가져오도록 최적화

[기존 쿼리 : 10개의 북마크 컨테츠를 조회할 때 12번(1+10+1)번 쿼리 실행]
-> 사용자 조회(1) + 북마크 목록 조회(1) + 북마크 수만큼 콘텐츠 개별 조회(10)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1cf2df7a-5a32-4d6a-a948-3fc2c6076a3e" />
<br/><br/>

[개선된 쿼리: 북마크 수에 관계없이 (User 조회 1회) + (Bookmark + Content 조회 1회), 총 2번의 쿼리로 조회 완료]

<img width="300" alt="image" src="https://github.com/user-attachments/assets/280d20b0-0d18-4dc3-82e4-5ecb5dbbd0f6" />


  <br/>

## 🔧 앞으로의 과제

- 북마크 조회 외에 다른 조회 API에서도 N+1 발생 여부를 점검하고 최적화 필요
