### PR TITLE
Feat 129

### DIFF
--- a/src/main/java/com/haruhan/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/haruhan/dashboard/controller/DashboardController.java
@@ -1,0 +1,27 @@
+package com.haruhan.dashboard.controller;
+
+import com.haruhan.common.error.StatusCode;
+import com.haruhan.common.error.dto.Message;
+import com.haruhan.dashboard.dto.DashboardResDto;
+import com.haruhan.dashboard.service.DashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dashboard")
+@CrossOrigin
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping
+    public ResponseEntity<Message> getDashboardInfo() {
+        DashboardResDto dashboardResDto = dashboardService.getDashboardInfo();
+        return ResponseEntity.ok(new Message(StatusCode.OK, dashboardResDto));
+    }
+}

--- a/src/main/java/com/haruhan/dashboard/dto/DashboardContentDto.java
+++ b/src/main/java/com/haruhan/dashboard/dto/DashboardContentDto.java
@@ -1,0 +1,6 @@
+package com.haruhan.dashboard.dto;
+
+public record DashboardContentDto (
+        Long contentId,
+        String title
+) {}

--- a/src/main/java/com/haruhan/dashboard/dto/DashboardResDto.java
+++ b/src/main/java/com/haruhan/dashboard/dto/DashboardResDto.java
@@ -1,0 +1,8 @@
+package com.haruhan.dashboard.dto;
+
+import java.util.List;
+
+public record DashboardResDto (
+        List<DashboardUserDto> users,
+        List<DashboardContentDto> contents
+) {}

--- a/src/main/java/com/haruhan/dashboard/dto/DashboardUserDto.java
+++ b/src/main/java/com/haruhan/dashboard/dto/DashboardUserDto.java
@@ -1,0 +1,6 @@
+package com.haruhan.dashboard.dto;
+
+public record DashboardUserDto (
+        Long userId,
+        String email
+) {}

--- a/src/main/java/com/haruhan/dashboard/service/DashboardService.java
+++ b/src/main/java/com/haruhan/dashboard/service/DashboardService.java
@@ -1,0 +1,7 @@
+package com.haruhan.dashboard.service;
+
+import com.haruhan.dashboard.dto.DashboardResDto;
+
+public interface DashboardService {
+    DashboardResDto getDashboardInfo();
+}

--- a/src/main/java/com/haruhan/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/haruhan/dashboard/service/DashboardServiceImpl.java
@@ -1,0 +1,35 @@
+package com.haruhan.dashboard.service;
+
+import com.haruhan.content.repository.ContentRepository;
+import com.haruhan.dashboard.dto.DashboardContentDto;
+import com.haruhan.dashboard.dto.DashboardResDto;
+import com.haruhan.dashboard.dto.DashboardUserDto;
+import com.haruhan.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardServiceImpl implements DashboardService {
+
+    private final UserRepository userRepository;
+    private final ContentRepository contentRepository;
+
+    @Override
+    public DashboardResDto getDashboardInfo() {
+        //사용자 정보 조회
+        List<DashboardUserDto> users = userRepository.findAll().stream()
+                .map(user -> new DashboardUserDto(user.getUserId(), user.getEmail()))
+                .toList();
+
+        //컨텐츠 정보 조회
+        List<DashboardContentDto> contents = contentRepository.findAll().stream()
+                .map(content -> new DashboardContentDto(content.getContentId(), content.getTitle()))
+                .toList();
+
+        return new DashboardResDto(users, contents);
+    }
+}


### PR DESCRIPTION
- 제목 : feat(129): 대시보드 조회

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 관리자 대시보드에 필요한 사용자 정보(id, email)와 콘텐츠 정보(id, title)를 통합 조회하는 API를 추가

- 프론트엔드가 대시보드 데이터를 별도 API 호출 없이 한 번에 조회할 수 있도록 구현

  <br/>

## 🔧 앞으로의 과제

- 사용자 수, 컨텐츠 수 같은 추가 정보가 필요할 경우 API 확장
