### PR TITLE
fix: 관리자 페이지에서 유저 및 컨텐츠 조회할 시 페이징 처리

### DIFF
--- a/src/main/java/com/haruhan/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/haruhan/dashboard/controller/DashboardController.java
@@ -6,10 +6,7 @@ import com.haruhan.dashboard.dto.DashboardResDto;
 import com.haruhan.dashboard.service.DashboardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +17,10 @@ public class DashboardController {
     private final DashboardService dashboardService;
 
     @GetMapping
-    public ResponseEntity<Message> getDashboardInfo() {
-        DashboardResDto dashboardResDto = dashboardService.getDashboardInfo();
+    public ResponseEntity<Message> getDashboardInfo(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        DashboardResDto dashboardResDto = dashboardService.getDashboardInfo(page, size);
         return ResponseEntity.ok(new Message(StatusCode.OK, dashboardResDto));
     }
 

--- a/src/main/java/com/haruhan/dashboard/dto/DashboardResDto.java
+++ b/src/main/java/com/haruhan/dashboard/dto/DashboardResDto.java
@@ -1,8 +1,9 @@
 package com.haruhan.dashboard.dto;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
 
-public record DashboardResDto (
-        List<DashboardUserDto> users,
-        List<DashboardContentDto> contents
-) {}
+public record DashboardResDto(
+        Page<DashboardUserDto> users,
+        Page<DashboardContentDto> contents
+) {
+}

--- a/src/main/java/com/haruhan/dashboard/service/DashboardService.java
+++ b/src/main/java/com/haruhan/dashboard/service/DashboardService.java
@@ -3,5 +3,5 @@ package com.haruhan.dashboard.service;
 import com.haruhan.dashboard.dto.DashboardResDto;
 
 public interface DashboardService {
-    DashboardResDto getDashboardInfo();
+    DashboardResDto getDashboardInfo(int page, int size);
 }

--- a/src/main/java/com/haruhan/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/haruhan/dashboard/service/DashboardServiceImpl.java
@@ -1,15 +1,17 @@
 package com.haruhan.dashboard.service;
 
+import com.haruhan.content.entity.Content;
 import com.haruhan.content.repository.ContentRepository;
 import com.haruhan.dashboard.dto.DashboardContentDto;
 import com.haruhan.dashboard.dto.DashboardResDto;
 import com.haruhan.dashboard.dto.DashboardUserDto;
+import com.haruhan.user.entity.User;
 import com.haruhan.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,16 +21,16 @@ public class DashboardServiceImpl implements DashboardService {
     private final ContentRepository contentRepository;
 
     @Override
-    public DashboardResDto getDashboardInfo() {
-        //사용자 정보 조회
-        List<DashboardUserDto> users = userRepository.findAll().stream()
-                .map(user -> new DashboardUserDto(user.getUserId(), user.getEmail()))
-                .toList();
+    public DashboardResDto getDashboardInfo(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
 
-        //컨텐츠 정보 조회
-        List<DashboardContentDto> contents = contentRepository.findAll().stream()
-                .map(content -> new DashboardContentDto(content.getContentId(), content.getTitle()))
-                .toList();
+        // 사용자 정보 조회
+        Page<User> userPage = userRepository.findAll(pageable);
+        Page<DashboardUserDto> users = userPage.map(user -> new DashboardUserDto(user.getUserId(), user.getEmail()));
+
+        // 컨텐츠 정보 조회
+        Page<Content> contentPage = contentRepository.findAll(pageable);
+        Page<DashboardContentDto> contents = contentPage.map(content -> new DashboardContentDto(content.getContentId(), content.getTitle()));
 
         return new DashboardResDto(users, contents);
     }


### PR DESCRIPTION
- 제목 : fix(134): User, Content 조회시 페이징 처리 하도록 로직 변경

## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

- 관리자 페이지에서 User, Content 조회하는 로직 변경
- 조회할 때 pageable 인터페이스를 활용해서 page, size로 나누어 조회하도록 수정

  <br/>

## 🔧 앞으로의 과제

- 인공지능 관련 기능 기획 및 추가
- 서비스 유지 보수

  <br/>

## ➕ 이슈 링크

- [BE #134]

<br/>
